### PR TITLE
Removing Promise.resolve call from plugin callback

### DIFF
--- a/lib/alterAssetTags.js
+++ b/lib/alterAssetTags.js
@@ -34,8 +34,6 @@ function alterAssetTags(compilation, htmlPluginData, callback) {
 
   if (typeof callback === "function") {
     callback(null, htmlPluginData);
-  } else {
-    return Promise.resolve(htmlPluginData);
   }
 }
 

--- a/lib/alterAssetTags.test.js
+++ b/lib/alterAssetTags.test.js
@@ -45,37 +45,6 @@ test('add tag and callback', function() {
   expect(htmlPluginData.head[0].attributes.defer).toBe(true);
 })
 
-test('promise', async function() {
-  var compilation = {};
-  var plugin = mockPlugin({ async: true });
-  var htmlPluginData = mockHtmlPluginData(
-    {
-      attributes: {
-        defer: true
-      }
-    },
-    [
-      {
-        tagName: "script",
-        attributes: {}
-      }
-    ],
-    [
-      {
-        tagName: "script",
-        attributes: {}
-      }
-    ]
-  );
-  await expect(
-    alterAssetTags.call(plugin, compilation, htmlPluginData)
-  ).resolves.toBe(htmlPluginData);
-  expect(htmlPluginData.body[0].attributes.async).toBe(true);
-  expect(htmlPluginData.body[0].attributes.defer).toBe(true);
-  expect(htmlPluginData.head[0].attributes.async).toBe(true);
-  expect(htmlPluginData.head[0].attributes.defer).toBe(true);
-})
-
 test("object", async function() {
   var obj = {a: 'a', b: 'b'}
   var compilation = {};


### PR DESCRIPTION
I was having an issue using this plugin along with `favicons-webpack-plugin`. 

![image](https://user-images.githubusercontent.com/11337615/101413040-5c670b80-38c2-11eb-92be-b21afa6aa88f.png)

After some debugging, i found out the problem was [this Promise.resolve call](https://github.com/dyw934854565/html-webpack-inject-attributes-plugin/blob/master/lib/alterAssetTags.js#L38) in the plugin callback. As far as i can tell, we don't need to handle a callback with promises since the plugin only uses synchronous tap from the Webpack API. The favicons plugin worked just fine.

I opened this PR, but let me know if this `Promise.resolve` is needed somewhere, so i can find another workaround.
